### PR TITLE
Make soundcard modem work on modern glibc and remove some warnings

### DIFF
--- a/lmsoundcard.c
+++ b/lmsoundcard.c
@@ -1,5 +1,6 @@
 /* sample interface code to use a linux soundcard */
 #define _XOPEN_SOURCE
+#define _XOPEN_SOURCE_EXTENDED
 #include <stdlib.h>
 #include <sys/select.h>
 #include <unistd.h>

--- a/lmsoundcard.c
+++ b/lmsoundcard.c
@@ -38,8 +38,14 @@ void soundcard_modem(void)
             perror("/dev/ptmx");
             return;
         }
-        grantpt(tty_handle);
-        unlockpt(tty_handle);
+        if (grantpt(tty_handle) < 0) {
+            perror("grantpt");
+            return;
+        }
+        if (unlockpt(tty_handle) < 0) {
+            perror("unlockpt");
+            return;
+        }
         printf("linmodem tty is '%s'\n", ptsname(tty_handle));
     } else {
         printf("linmodem tty is stdout\n");

--- a/v90.c
+++ b/v90.c
@@ -586,7 +586,8 @@ static void v90_send_CP(V90DecodeState *s, int is_CP, int ack)
     put_bits(&p, 16, crc);
 
     put_bits(&p, 3, 0); /* fill */
-    printf("CP size= %d\n", p - buf);
+    int cp_size = p - buf;
+    printf("CP size= %d\n", cp_size);
 }
 
 static int get_bit(u8 **pp)


### PR DESCRIPTION
Make the soundcard modem work with glibc 2.24 and newer (see grantpt man page for details). Also, add some error handling and avoid some compiler warnings.

Before the patch using `-t` made segmentation fault.